### PR TITLE
Use signer uri for succinct key

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           TUF_REPO_PRIVATE_KEY_fb8a7fd2030a0d991af8855dc6093eb3029fee110f73abc63ee94e87ad50b2c2: ${{ secrets.TUF_REPO_PRIVATE_KEY_fb8a7fd2030a0d991af8855dc6093eb3029fee110f73abc63ee94e87ad50b2c2 }}
         run: |
-          tufrepo --keyring=env sign --all-targets
+          tufrepo --keyring=uri sign --all-targets
 
       - name: Snapshot
         id: snapshot

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Snapshot
         id: snapshot
         working-directory: metadata
-        env:
-          TUF_REPO_PRIVATE_KEY_38600820f11a5f7d7ff42e6dfc9b03fd60272a3be6f895da2d882cea8bb1e20f: ${{ secrets.TUF_REPO_PRIVATE_KEY_38600820f11a5f7d7ff42e6dfc9b03fd60272a3be6f895da2d882cea8bb1e20f }}
-          TUF_REPO_PRIVATE_KEY_9d78543b508f99a95a3c31fad3cffef0644134f1a028b30501acc12058c7c3e8: ${{ secrets.TUF_REPO_PRIVATE_KEY_9d78543b508f99a95a3c31fad3cffef0644134f1a028b30501acc12058c7c3e8 }}
         run: |
           tufrepo --keyring=uri snapshot
           # verify that result is a functional repository

--- a/.github/workflows/timestamp.yml
+++ b/.github/workflows/timestamp.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Timestamp
         working-directory: metadata
-        env:
-          TUF_REPO_PRIVATE_KEY_38600820f11a5f7d7ff42e6dfc9b03fd60272a3be6f895da2d882cea8bb1e20f: ${{ secrets.TUF_REPO_PRIVATE_KEY_38600820f11a5f7d7ff42e6dfc9b03fd60272a3be6f895da2d882cea8bb1e20f }}
         run: |
           # verify is currently not able to tell e.g. expiry from real invalid metadata
           # so we can't verify before trying to timestamp

--- a/metadata/3.demo.json
+++ b/metadata/3.demo.json
@@ -1,0 +1,37 @@
+{
+ "signatures": [
+  {
+   "keyid": "63f448490147d70c0a98def45abecd792261411d14e228c2567cb5cbe4010598",
+   "sig": "907bd587bbd565fd47528c9de4d2245d2b76202a4c092788d5966488c0e8f8cd5159c9354b7a84981078597f5f175881c7d71c6297833dd1325197e197780603"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "delegations": {
+   "keys": {
+    "fb8a7fd2030a0d991af8855dc6093eb3029fee110f73abc63ee94e87ad50b2c2": {
+     "keyid": "fb8a7fd2030a0d991af8855dc6093eb3029fee110f73abc63ee94e87ad50b2c2",
+     "keytype": "ed25519",
+     "keyval": {
+      "public": "c93fd37f7d94b8c90668d0de683787e73324ab20de0f15e4127916d83b00d32b"
+     },
+     "scheme": "ed25519",
+     "x-tufrepo-online-uri": "envvar:TUF_REPO_PRIVATE_KEY_fb8a7fd2030a0d991af8855dc6093eb3029fee110f73abc63ee94e87ad50b2c2"
+    }
+   },
+   "succinct_roles": {
+    "bit_length": 5,
+    "keyids": [
+     "fb8a7fd2030a0d991af8855dc6093eb3029fee110f73abc63ee94e87ad50b2c2"
+    ],
+    "name_prefix": "demo-bin",
+    "threshold": 1
+   }
+  },
+  "expires": "2023-12-16T15:54:15Z",
+  "spec_version": "1.0.19",
+  "targets": {},
+  "version": 3,
+  "x-tufrepo-expiry-period": 31449600
+ }
+}


### PR DESCRIPTION
This way all online signers use the signer uris and the same Keyring (even though one is a envvar key and two use Google Cloud KMS).