### PR TITLE
Add more demo content

### DIFF
--- a/metadata/2.demo-bin-0f.json
+++ b/metadata/2.demo-bin-0f.json
@@ -1,0 +1,18 @@
+{
+ "signatures": [],
+ "signed": {
+  "_type": "targets",
+  "expires": "2023-12-17T17:21:47Z",
+  "spec_version": "1.0.30",
+  "targets": {
+   "demo/succinctly-delegated-12.txt": {
+    "hashes": {
+     "sha256": "f88eb9487673d6390659c80e2416490b3c12c17c733bf09294f463384feb7d5d"
+    },
+    "length": 34
+   }
+  },
+  "version": 2,
+  "x-tufrepo-expiry-period": 31536000
+ }
+}

--- a/targets/demo/f88eb9487673d6390659c80e2416490b3c12c17c733bf09294f463384feb7d5d.succinctly-delegated-12.txt
+++ b/targets/demo/f88eb9487673d6390659c80e2416490b3c12c17c733bf09294f463384feb7d5d.succinctly-delegated-12.txt
@@ -1,0 +1,1 @@
+succinctly-delegated-12.txt

--- a/targets/demo/succinctly-delegated-12.txt
+++ b/targets/demo/succinctly-delegated-12.txt
@@ -1,0 +1,1 @@
+more succinctly delegated content


### PR DESCRIPTION
command was
`tufrepo add-target demo/succinctly-delegated-12.txt ../targets/demo/succinctly-delegated-12.txt`

* this is delegated to a succinct delegation
* purpose is to test that the online succinct delegation key still works after switching to signer uri keyring